### PR TITLE
refactor turrets rotate and shoot attack

### DIFF
--- a/Assets/Prefabs/TurretSpawn.prefab
+++ b/Assets/Prefabs/TurretSpawn.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2879626826325038938
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8764822074806927970}
+  - component: {fileID: 2654412365155729148}
+  m_Layer: 0
+  m_Name: TurretSpawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 2488908585195742037, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8764822074806927970
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2879626826325038938}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2654412365155729148
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2879626826325038938}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 945dacf5c8af64bc496730d07f9dee42, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bullet: {fileID: 5908108148281989759, guid: a3770aab7371f4bdfa10c3e6727f8987, type: 3}

--- a/Assets/Prefabs/TurretSpawn.prefab.meta
+++ b/Assets/Prefabs/TurretSpawn.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bf9461cee7ed64744beaa3f24fe90bbf
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BulletController.cs
+++ b/Assets/Scripts/BulletController.cs
@@ -9,7 +9,7 @@ detection, and deletion after time of bullets that missed.
 */
 public class BulletController : MonoBehaviour
 {
-    const float sniperBulletSpeed = 50f;
+    const float sniperBulletSpeed = 70f;
     const float rotationSpeed = 100f;
     const float maxLifetime = 2f;
     float bulletLifetime;
@@ -62,7 +62,8 @@ public class BulletController : MonoBehaviour
             Debug.Log("collided with arena");
             Destroy(gameObject);
         }
-        else if (collision.gameObject.tag == "Player"){
+        else if (collision.gameObject.tag == "Player")
+        {
             PlayerStatus playerStatus = collision.gameObject.GetComponent<PlayerStatus>();
             if (playerStatus != null) // Check if the PlayerStatus component is found
             {

--- a/Assets/Scripts/BulletController.cs
+++ b/Assets/Scripts/BulletController.cs
@@ -9,7 +9,7 @@ detection, and deletion after time of bullets that missed.
 */
 public class BulletController : MonoBehaviour
 {
-    const float sniperBulletSpeed = 70f;
+    const float sniperBulletSpeed = 80f;
     const float rotationSpeed = 100f;
     const float maxLifetime = 2f;
     float bulletLifetime;

--- a/Assets/Scripts/InitSniperShooting.cs
+++ b/Assets/Scripts/InitSniperShooting.cs
@@ -13,7 +13,7 @@ public class InitSniperShooting : MonoBehaviour
     private GameObject player;
     private Vector3 playerShootPosition;
     private Vector3 prevRotation;
-    private const float turretRotationSpeed = 4f;
+    private const float turretRotationSpeed = 5f;
     private bool aiming;
     private bool readyToShoot;
 

--- a/Assets/Scripts/SprayAttackController.cs
+++ b/Assets/Scripts/SprayAttackController.cs
@@ -39,6 +39,16 @@ public class SprayAttackController : MonoBehaviour
         }
     }
 
+    /**
+   Can be called by some AI controller to trigger the Shoot and Rotate attack.
+   Note:  intentionally not in use while we are using timer above.
+   */
+    public void TriggerShootAndRotate()
+    {
+        StartCoroutine(TripleShootAndRotate(turrets));
+    }
+
+
     IEnumerator TripleShootAndRotate(ShootSprayBullet[] turrets)
     {
         // First round of shots.

--- a/Assets/Scripts/SprayBulletController.cs
+++ b/Assets/Scripts/SprayBulletController.cs
@@ -10,7 +10,7 @@ detection, and deletion after time of bullets that missed.
 public class SprayBulletController : MonoBehaviour
 {
     const float sprayBulletSpeed = 50f;
-    const float maxLifetime = 3f;
+    const float maxLifetime = 2f;
     float bulletLifetime;
 
     GameObject boss;

--- a/Assets/Scripts/SprayBulletController.cs
+++ b/Assets/Scripts/SprayBulletController.cs
@@ -9,20 +9,17 @@ detection, and deletion after time of bullets that missed.
 */
 public class SprayBulletController : MonoBehaviour
 {
-    const float sprayBulletSpeed = 60f;
-    // const float rotationSpeed = 100f;
+    const float sprayBulletSpeed = 50f;
     const float maxLifetime = 3f;
     float bulletLifetime;
-    // private Vector3 rot;
-    // GameObject sniper;
+
     GameObject boss;
     private CapsuleCollider bulletCollider;
     private CapsuleCollider bossCollider;
-    public float damage = 20f;
+    public float damage = 10f;
 
     void Start()
     {
-        // sniper = GameObject.Find("Sniper");
         boss = GameObject.Find("Cube");  // We should fix this name.
 
         bulletLifetime = 0f;
@@ -55,7 +52,7 @@ public class SprayBulletController : MonoBehaviour
     {
         if (collision.gameObject.tag == "Arena")
         {
-            Debug.Log("collided with arena");
+            // Debug.Log("collided with arena");
             Destroy(gameObject);
         }
         else if (collision.gameObject.tag == "Player")
@@ -64,17 +61,13 @@ public class SprayBulletController : MonoBehaviour
             if (playerStatus != null) // Check if the PlayerStatus component is found
             {
                 playerStatus.TakeDamage(damage);
-                Debug.Log("collided with player");
+                // Debug.Log("collided with player");
             }
             else
             {
-                Debug.Log("PlayerStatus component not found on the collided object.");
+                // Debug.Log("PlayerStatus component not found on the collided object.");
             }
             Destroy(gameObject);
-        }
-        else
-        {
-            Debug.Log("Something else?");
         }
     }
 }


### PR DESCRIPTION
Major changes are to the scene itself and to the SprayAttackController

- adds turret spawn prefabs
- refactor SprayAttackController to find a rotation differently
- update the scene to: 
 ->  include the turret spawns, 
 -> move turrets around
 -> add targets to columns for the turrets to shoot at (find the correct direction)
- shorten bullets lifetime 3 -> 2.
- make sniper rotate faster and sniper bullets move faster