### PR TITLE
Turret indicators - Indicators V1 is complete

### DIFF
--- a/Assets/Scripts/BossScripts/BossHealth.cs
+++ b/Assets/Scripts/BossScripts/BossHealth.cs
@@ -25,19 +25,19 @@ public class BossHealth : MonoBehaviour
         }
         else
         {
-           Debug.LogWarning(DifficultyManager.phase);
-           healthBar.SetSliderMax(maxHealth / 2);
-           healthBar2.SetSliderMax(maxHealth / 2);
-        
+            Debug.LogWarning(DifficultyManager.phase);
+            healthBar.SetSliderMax(maxHealth / 2);
+            healthBar2.SetSliderMax(maxHealth / 2);
+
             if (DifficultyManager.phase == 2)
             {
                 currHealth = maxHealth / 2;
-                Debug.Log("SETTING HEALTH TO HALF: " + currHealth);
+                // Debug.Log("SETTING HEALTH TO HALF: " + currHealth);
                 healthBar.SetSlider(0f);
             }
         }
         playerControl = FindObjectOfType<PlayerControl>();
-        
+
     }
     public void TakeDamage(float amount)
     {
@@ -86,7 +86,7 @@ public class BossHealth : MonoBehaviour
         AudioManager.instance.PhaseMusicChange(3);
         StartCoroutine(fade.FadeToBlack());
     }
-    
+
 
     public void resetHealth()
     {

--- a/Assets/Scripts/BossScripts/BossStates.cs
+++ b/Assets/Scripts/BossScripts/BossStates.cs
@@ -200,7 +200,7 @@ public class BossStates : MonoBehaviour
         if (spiralAttack != null)
         {
             // Debug.Log("Performing Spiral Attack");
-            spiralAttack.TriggerShootAndRotate();
+            spiralAttack.TriggerAttack();
         }
     }
 

--- a/Assets/Scripts/BossScripts/BossStates.cs
+++ b/Assets/Scripts/BossScripts/BossStates.cs
@@ -41,8 +41,8 @@ public class BossStates : MonoBehaviour
                 isSleeping = true;
                 break;
         }
-        Debug.Log(isSleeping);
-        Debug.Log(DifficultyManager.phase);
+        // Debug.Log(isSleeping);
+        // Debug.Log(DifficultyManager.phase);
     }
     void Update()
     {
@@ -64,7 +64,7 @@ public class BossStates : MonoBehaviour
                 currentState = BossState.Attacking;
                 break;
             case BossState.Attacking:
-                Debug.Log("Attempting to Perform Attack");
+                // Debug.Log("Attempting to Perform Attack");
                 PerformAttack(nextAttack);
                 currentState = BossState.Cooldown;
                 break;

--- a/Assets/Scripts/BossScripts/SlamAttack.cs
+++ b/Assets/Scripts/BossScripts/SlamAttack.cs
@@ -38,7 +38,7 @@ public class SlamAttack : MonoBehaviour, IWarningGenerator
     private IEnumerator AttackSequence(int tileIndex)
     {
 
-        List<string> warned = warningManager.ToggleWarning(GetWarningTiles(), true, WarningManager.WarningType.SLAM);
+        List<string> warned = warningManager.ToggleWarning(GetWarningObjects(), true, WarningManager.WarningType.SLAM);
         // foreach (var ring in arenaInitializer.tilePositions)
         // {
         //     if (tileIndex < ring.Count)
@@ -103,14 +103,13 @@ public class SlamAttack : MonoBehaviour, IWarningGenerator
     }
 
     // Satisfies IWarningGenerator interface
-    public List<string> GetWarningTiles()
+    public List<string> GetWarningObjects()
     {
         Dictionary<(int, int), string> mapping = warningManager.GetLogicalToPhysicalTileMapping();
         string tilename = mapping[(playerControl.currentRingIndex, playerControl.currentTileIndex)];
 
         // Pluck out the left-right index of the current tile
         string leftRightIndex = tilename.Substring(3, 2);
-        Debug.Log($"slam GetWarning {leftRightIndex}");
 
         return new List<string> {
             $"R1_{leftRightIndex}",

--- a/Assets/Scripts/BossScripts/SniperAttack.cs
+++ b/Assets/Scripts/BossScripts/SniperAttack.cs
@@ -55,7 +55,7 @@ public class SniperAttack : MonoBehaviour, IWarningGenerator
             aiming = true;
             playerShootPosition = player.transform.position;  // The location that the player WAS when they missed a beat, not current.
             // Show a warning based on current location of player
-            warningManager.ToggleWarning(GetWarningTiles(), true, WarningManager.WarningType.SNIPER);
+            warningManager.ToggleWarning(GetWarningObjects(), true, WarningManager.WarningType.SNIPER);
 
             StartCoroutine(ShootAfterRotation());
         }
@@ -65,7 +65,7 @@ public class SniperAttack : MonoBehaviour, IWarningGenerator
     /**
         Determines the name of the physical tile the player is currently on, adds to list and returns.
     */
-    public List<string> GetWarningTiles()
+    public List<string> GetWarningObjects()
     {
         Dictionary<(int, int), string> mapping = warningManager.GetLogicalToPhysicalTileMapping();
         return new List<string> { mapping[(playerControl.currentRingIndex, playerControl.currentTileIndex)] }; ;

--- a/Assets/Scripts/BossScripts/SniperBulletController.cs
+++ b/Assets/Scripts/BossScripts/SniperBulletController.cs
@@ -97,7 +97,7 @@ public class SniperBulletController : MonoBehaviour
 
     void OnDestroy()
     {
-        List<string> sniperWarnings = warningManager.GetWarningsOfType(WarningManager.WarningType.SNIPER);
+        List<string> sniperWarnings = warningManager.GetSniperWarnings();
         warningManager.ToggleWarning(sniperWarnings.GetRange(0, 1), false, WarningManager.WarningType.SNIPER);
     }
 }

--- a/Assets/Scripts/BossScripts/SpiralAttack.cs
+++ b/Assets/Scripts/BossScripts/SpiralAttack.cs
@@ -24,10 +24,9 @@ public class SpiralAttack : MonoBehaviour
 
 
     /**
-   Can be called by some AI controller to trigger the Shoot and Rotate attack.
-   Note:  intentionally not in use while we are using timer above.
-   */
-    public void TriggerShootAndRotate()
+        Begins the turret rotate-and-shoot attack.
+    */
+    public void TriggerAttack()
     {
         StartCoroutine(TripleShootAndRotate(turrets));
     }

--- a/Assets/Scripts/BossScripts/SpiralAttack.cs
+++ b/Assets/Scripts/BossScripts/SpiralAttack.cs
@@ -10,9 +10,11 @@ public class SpiralAttack : MonoBehaviour
     GameObject turretsRig;
     GameObject targetsParent;
     const float turretRotationSpeed = 20f;
+    const float warningTime = 0.5f;
     ShootSpiralBullet[] turrets;
     int currTargetIndex;
     const int NUM_SLICES = 24;
+    private WarningManager warningManager;
 
     void Start()
     {
@@ -20,6 +22,8 @@ public class SpiralAttack : MonoBehaviour
         targetsParent = GameObject.Find("SpiralTargets");
         currTargetIndex = 0;
         turrets = FindObjectsOfType<ShootSpiralBullet>();
+        // Flash warning on turrets themselves when attacking
+        warningManager = WarningManager.Instance;
     }
 
 
@@ -35,11 +39,7 @@ public class SpiralAttack : MonoBehaviour
     IEnumerator TripleShootAndRotate(ShootSpiralBullet[] turrets)
     {
         // First round of shots.
-        foreach (ShootSpiralBullet turret in turrets)
-        {
-            turret.Shoot();  // assume shoots at first index of 0 
-        }
-        turrets[0].PlaySound();
+        Shoot(turrets);
         // increment the target index because we already shot at above.
         currTargetIndex = (currTargetIndex + 1) % NUM_SLICES;
         // Determine position of child to shoot at.
@@ -55,11 +55,7 @@ public class SpiralAttack : MonoBehaviour
 
         yield return new WaitForSeconds(0.5f);  // adds some padding between shoot and rotations
         // Second round of shots.
-        foreach (ShootSpiralBullet turret in turrets)
-        {
-            turret.Shoot();
-        }
-        turrets[0].PlaySound();
+        Shoot(turrets);
         // increment the target index
         currTargetIndex = (currTargetIndex + 1) % NUM_SLICES;
         // Determine position of child to shoot at
@@ -76,10 +72,29 @@ public class SpiralAttack : MonoBehaviour
         yield return new WaitForSeconds(0.5f);
 
         // Third and final round of shots until attack is triggered again.
+        Shoot(turrets);
+    }
+
+    private void Shoot(ShootSpiralBullet[] turrets)
+    {
         foreach (ShootSpiralBullet turret in turrets)
         {
             turret.Shoot();
         }
         turrets[0].PlaySound();
+    }
+
+    public List<string> GetWarningObjects()
+    {
+        return new List<string> {
+            "turret1",
+            "turret2",
+            "turret3",
+            "turret4",
+            "turret5",
+            "turret6",
+            "turret7",
+            "turret8",
+        };
     }
 }

--- a/Assets/Scripts/BossScripts/SpiralAttack.cs
+++ b/Assets/Scripts/BossScripts/SpiralAttack.cs
@@ -38,7 +38,11 @@ public class SpiralAttack : MonoBehaviour
 
     IEnumerator TripleShootAndRotate(ShootSpiralBullet[] turrets)
     {
+        // Offer warning blinks
+        warningManager.ToggleWarning(GetWarningObjects(), true, WarningManager.WarningType.SPIRAL);
+        yield return new WaitForSeconds(warningTime);  // adds some padding between shoot and rotations
         // First round of shots.
+        warningManager.ToggleWarning(GetWarningObjects(), false, WarningManager.WarningType.SPIRAL);
         Shoot(turrets);
         // increment the target index because we already shot at above.
         currTargetIndex = (currTargetIndex + 1) % NUM_SLICES;
@@ -52,8 +56,9 @@ public class SpiralAttack : MonoBehaviour
             turretsRig.transform.rotation = Quaternion.RotateTowards(turretsRig.transform.rotation, firstTargetRotation, turretRotationSpeed * Time.deltaTime);
             yield return null;
         }
-
-        yield return new WaitForSeconds(0.5f);  // adds some padding between shoot and rotations
+        warningManager.ToggleWarning(GetWarningObjects(), true, WarningManager.WarningType.SPIRAL);
+        yield return new WaitForSeconds(warningTime);  // adds some padding between shoot and rotations
+        warningManager.ToggleWarning(GetWarningObjects(), false, WarningManager.WarningType.SPIRAL);
         // Second round of shots.
         Shoot(turrets);
         // increment the target index
@@ -68,8 +73,9 @@ public class SpiralAttack : MonoBehaviour
             turretsRig.transform.rotation = Quaternion.RotateTowards(turretsRig.transform.rotation, secondTargetRotation, turretRotationSpeed * Time.deltaTime);
             yield return null;
         }
-
-        yield return new WaitForSeconds(0.5f);
+        warningManager.ToggleWarning(GetWarningObjects(), true, WarningManager.WarningType.SPIRAL);
+        yield return new WaitForSeconds(warningTime);
+        warningManager.ToggleWarning(GetWarningObjects(), false, WarningManager.WarningType.SPIRAL);
 
         // Third and final round of shots until attack is triggered again.
         Shoot(turrets);

--- a/Assets/Scripts/BossScripts/SteamAttack.cs
+++ b/Assets/Scripts/BossScripts/SteamAttack.cs
@@ -72,12 +72,12 @@ public class SteamAttack : MonoBehaviour, IWarningGenerator
         warningText.gameObject.SetActive(true);
         warningText.text = "Back Up!!";
         StartCoroutine(FlashWarningText());
-        warningManager.ToggleWarning(GetWarningTiles(), true, WarningManager.WarningType.STEAM);
+        warningManager.ToggleWarning(GetWarningObjects(), true, WarningManager.WarningType.STEAM);
         // Switch to warning material
         attackAreaRenderer.material = warningMaterial;
         // Wait for the warning duration
         yield return new WaitForSeconds(warningDuration);
-        warningManager.ToggleWarning(GetWarningTiles(), false, WarningManager.WarningType.STEAM);
+        warningManager.ToggleWarning(GetWarningObjects(), false, WarningManager.WarningType.STEAM);
         attackAreaRenderer.material = attackMaterial;
         yield return new WaitForSeconds(0.1f);
         warningText.gameObject.SetActive(false);
@@ -146,7 +146,7 @@ public class SteamAttack : MonoBehaviour, IWarningGenerator
     /**
         Return the GameObject names of all tiles that need to be highlighted for this warning.
     */
-    public List<string> GetWarningTiles()
+    public List<string> GetWarningObjects()
     {
         return new List<string> {
             "R1_01",

--- a/Assets/Scripts/Interfaces/IWarningGenerator.cs
+++ b/Assets/Scripts/Interfaces/IWarningGenerator.cs
@@ -5,5 +5,5 @@ using System.Collections.Generic;
 */
 public interface IWarningGenerator
 {
-  public List<string> GetWarningTiles();
+  public List<string> GetWarningObjects();
 }

--- a/Assets/Scripts/PlayerControl.cs
+++ b/Assets/Scripts/PlayerControl.cs
@@ -88,7 +88,7 @@ public class PlayerControl : MonoBehaviour
     {
         var currentRing = arenaInitializer.tilePositions[currentRingIndex];
         currentTileIndex = (currentTileIndex + direction + currentRing.Count) % currentRing.Count;
-        Debug.Log($"Moving to adjacent tile, direction: {direction}");
+        // Debug.Log($"Moving to adjacent tile, direction: {direction}");
         MoveToCurrentTile();
     }
 

--- a/Assets/Scripts/WarningManager.cs
+++ b/Assets/Scripts/WarningManager.cs
@@ -17,12 +17,15 @@ public class WarningManager : MonoBehaviour
     private List<string> allWarnings;
 
     // for blink effect
-    [SerializeField] Color blinkStart;
-    [SerializeField] Color blinkEnd;
-    private GameObject tempTile;
+    [SerializeField] Color tileColor;
+    [SerializeField] Color turretColor;
+    [SerializeField] Color warningColor;
+    private const float turretBlinkSpeed = 0.3f;
+    private const float tileBlinkSpeed = 0.6f;
+    private GameObject tempObject;
     private MeshRenderer tempRenderer;
     private MaterialPropertyBlock propBlock;
-    // end blink effect
+    // end blink effect stuff
 
 
     public static WarningManager Instance { get; private set; }
@@ -60,13 +63,15 @@ public class WarningManager : MonoBehaviour
     void Update()
     {
         // Every name found in allWarnings should be blinking.
-        foreach (string tilename in allWarnings)
+        foreach (string name in allWarnings)
         {
-            tempTile = GameObject.Find(tilename);
-            tempRenderer = tempTile.GetComponent<MeshRenderer>();
+            tempObject = GameObject.Find(name);
+            tempRenderer = tempObject.GetComponent<MeshRenderer>();
             propBlock = new MaterialPropertyBlock();
             tempRenderer.GetPropertyBlock(propBlock);
-            propBlock.SetColor("_BaseColor", Color.Lerp(blinkStart, blinkEnd, Mathf.PingPong(Time.time, .6f)));
+            Color color = tempObject.CompareTag("Turret") ? turretColor : tileColor;
+            float speed = tempObject.CompareTag("Turret") ? turretBlinkSpeed : tileBlinkSpeed;
+            propBlock.SetColor("_BaseColor", Color.Lerp(color, warningColor, Mathf.PingPong(Time.time, speed)));
             tempRenderer.SetPropertyBlock(propBlock);
         }
     }
@@ -83,24 +88,24 @@ public class WarningManager : MonoBehaviour
 
         NOTE:  this puts the responsibility on various attacks to know which tiles they should warn about (using IWarningGenerator interface)
     */
-    public List<string> ToggleWarning(List<string> tiles, bool warningActive, WarningType type)
+    public List<string> ToggleWarning(List<string> objects, bool warningActive, WarningType type)
     {
-        for (int i = 0; i < tiles.Count; i++)
+        for (int i = 0; i < objects.Count; i++)
         {
-            GameObject tileToChange = GameObject.Find(tiles[i]);  // TO-DO: add error handling/null checks maybe
-            MeshRenderer renderer = tileToChange.GetComponent<MeshRenderer>();
+            GameObject objectToChange = GameObject.Find(objects[i]);  // TO-DO: add error handling/null checks maybe
+            MeshRenderer renderer = objectToChange.GetComponent<MeshRenderer>();
             if (warningActive)
             {
-                TrackWarning(tiles[i], type);  // So that Update function can make it blink
+                TrackWarning(objects[i], type);  // So that Update function can make it blink
             }
             else
             {
-                allWarnings.Remove(tiles[i]);
-                HandleRemoveSniper(type, tiles[i]);
-                HandleToggleMaterial(tiles[i], renderer);
+                allWarnings.Remove(objects[i]);
+                HandleRemoveSniper(type, objects[i]);
+                HandleToggleMaterial(objects[i], renderer, objectToChange.CompareTag("Turret"));
             }
         }
-        return tiles;
+        return objects;
     }
 
 
@@ -119,13 +124,13 @@ public class WarningManager : MonoBehaviour
     /**
         Keep this tile as the warning color if there is still another outstanding warning.
     */
-    private void HandleToggleMaterial(string tilename, MeshRenderer renderer)
+    private void HandleToggleMaterial(string name, MeshRenderer renderer, bool isTurret)
     {
-        if (!allWarnings.Contains(tilename))
+        if (!allWarnings.Contains(name))
         {
             propBlock = new MaterialPropertyBlock();
             renderer.GetPropertyBlock(propBlock);
-            propBlock.SetColor("_BaseColor", blinkStart);
+            propBlock.SetColor("_BaseColor", isTurret ? turretColor : tileColor);
             renderer.SetPropertyBlock(propBlock);
         }
     }
@@ -143,7 +148,7 @@ public class WarningManager : MonoBehaviour
                 allWarnings.Add(tileName);
                 break;
             default:
-                // Steam + Slam
+                // Steam, Slam, Spiral
                 allWarnings.Add(tileName);
                 break;
         }

--- a/Assets/Scripts/WarningManager.cs
+++ b/Assets/Scripts/WarningManager.cs
@@ -72,16 +72,9 @@ public class WarningManager : MonoBehaviour
     }
 
 
-    /** TO-DO: rename this if only sniper uses it */
-    public List<string> GetWarningsOfType(WarningType type)
+    public List<string> GetSniperWarnings()
     {
-        switch (type)
-        {
-            case WarningType.SNIPER:
-                return sniperWarnings;
-            default:
-                return new List<string>();
-        }
+        return sniperWarnings;
     }
 
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -8,6 +8,7 @@ TagManager:
   - Enviorment
   - Weapon
   - Arena
+  - Turret
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
- This implements indicators directly on the turret bodies, they blink for half a second between each shot.
- SpiralAttack implements IWarningGenerator interface
- This wraps up an initial indicators implementation for ALL attacks.
- Applies the "Turret" tag on turrets1-8
- renamed some stuff:  TriggerShootAndRotate -> TriggerAttack (consistent with others), GetWarningsOfType -> GetSniperWarnings, GetWarningTiles -> GetWarningObjects (introducing turrets which aren't tiles)


https://github.com/notjustine/Lucid-Mystery/assets/83475441/6ea3b044-1a83-4418-a108-838b5b5b4c02

